### PR TITLE
Quick fix to remove inactive players.

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -9,8 +9,10 @@
     <div id="br"></div>
 	<% count = 1 %>
 	<% @users.each do |user| %>
-	    <%= render :partial => "entry", :locals => {:position => count, :name => user.pool_name, :rating => user.rating } %>
-	  <% count += 1 %>
+            <% if user.rating >= 0 then %>
+	        <%= render :partial => "entry", :locals => {:position => count, :name => user.pool_name, :rating => user.rating } %>
+	        <% count += 1 %>
+            <% end %>
 	<% end %>
   </div>
   <div id="notifications">


### PR DESCRIPTION
Inactive players scores can be negated in the DB until they become active again. While the score is negated they won't appear on the scoreboard. If they return then their score can simply be negated again and they will reappear.
